### PR TITLE
[FIX]: using res.user field in widget domain of base automation

### DIFF
--- a/access_settings_menu/models.py
+++ b/access_settings_menu/models.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from odoo import api, models
 
 
@@ -7,4 +8,7 @@ class ResUsers(models.Model):
     @api.model
     def fields_get(self, *args, **kwargs):
         # switch to superuser to get access to virtual fields
+        # clean kwargs before call the function
+        sig = signature(super(ResUsers, self.sudo()).fields_get)
+        kwargs = {key: kwargs[key] for key in kwargs.keys() if sig.parameters.get(key)}
         return super(ResUsers, self.sudo()).fields_get(*args, **kwargs)


### PR DESCRIPTION
When i select `res.user` field for domain in base.automation, there will be a context variable inside the `kwargs` argument that raises an error. so i needed to cleanup the keys before calling the super function.