### PR TITLE
[12.0] access_limit_max_users: fixed impossibility to successfully edit any user

### DIFF
--- a/access_limit_max_users/__manifest__.py
+++ b/access_limit_max_users/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Hidden",
     # "live_test_url": "http://apps.it-projects.info/shop/product/DEMO-URL?version=12.0",
     "images": [],
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "application": False,
     "author": "IT-Projects LLC, Eugene Molotov",
     "support": "help@itpp.dev",

--- a/access_limit_max_users/doc/changelog.rst
+++ b/access_limit_max_users/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.1.1`
+-------
+
+- **Fix**: Fixed impossibility to successfully edit any user
+
 `1.1.0`
 -------
 

--- a/access_limit_max_users/models/res_users.py
+++ b/access_limit_max_users/models/res_users.py
@@ -17,7 +17,7 @@ class ResUsers(models.Model):
             )
         return super(ResUsers, self).create(vals)
 
-    @api.model
+    @api.multi
     def write(self, vals):
         if vals.get("is_excluded_from_limiting") and not self.env.user._is_superuser():
             raise ValidationError(


### PR DESCRIPTION
Для воспроизводства надо выполнить следующий метод в shell-е:
```
from odoo.service.model import execute
execute("demotry1", 1, "res.users", "write", 1, {"name": "Mega-admin"})
```
Будет исключение вида:
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 185, in execute
    res = execute_cr(cr, uid, obj, method, *args, **kw)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 169, in execute_cr
    result = odoo.api.call_kw(recs, method, args, kw)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 755, in call_kw
    return _call_kw_model(method, model, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 728, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/mnt/addons/access-addons/access_limit_max_users/models/res_users.py", line 22, in write
    if vals.get("is_excluded_from_limiting") and not self.env.user._is_superuser():
AttributeError: 'int' object has no attribute 'get'
```